### PR TITLE
Lock down chrono version to one that uses serde 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,7 @@ serde_json = "0.9"
 serde_derive = "0.9"
 
 [dependencies.chrono]
-version = "0.3"
+# Locked to 0.3.0 since chrono 0.3.1 uses serde ^1, which is incompatible
+# with serde 0.9 specified above.
+version = "=0.3.0"
 features = ["serde"]


### PR DESCRIPTION
Hi! I tried to use mammut in a project and I couldn't get it to compile-- same problem when I compiled master of mammut by itself:

```
error[E0277]: the trait bound `chrono::DateTime<chrono::UTC>: serde::Deserialize` is not satisfied
 --> src/entities/account.rs:2:24
  |
2 | #[derive(Debug, Clone, Deserialize)]
  |                        ^^^^^^^^^^^ the trait `serde::Deserialize` is not implemented for `chrono::DateTime<chrono::UTC>`
  |
  = note: required by `serde::de::SeqVisitor::visit`
```

Looks like chrono released 0.3.1, which has a dependency requirement on serde of `^1` instead of `^0.9`. Serde >1 conflicts with mammut's serde 0.9 specification.

I tried it out, and locking chrono at 0.3.0 fixes it :)