### PR TITLE
Add missing #[serde(rename = "type")] to Notification::notification_type

### DIFF
--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -5,6 +5,7 @@ use super::status::Status;
 #[derive(Debug, Clone, Deserialize)]
 pub struct Notification {
     pub id: u64,
+    #[serde(rename = "type")]
     pub notification_type: NotificationType,
     pub created_at: DateTime<UTC>,
     pub account: Account,


### PR DESCRIPTION
Looks like `Mastodon::notifications` doesn't work.
```rust
// on my project

#[test]
fn fetch_notifications() {
    let ref mastodon: Mastodon = ...;
    mastodon.notifications().unwrap();
}


#[test]
fn fetch_notification_using_hyper() {
    use hyper::header::{Authorization, Bearer};
    use hyper::net::HttpsConnector;
    use hyper_native_tls::NativeTlsClient;

    let ref mastodon: Mastodon = ...;
    let client = {
        let tls = NativeTlsClient::new().unwrap();
        let connector = HttpsConnector::new(tls);
        Client::with_connector(connector)
    };
    let response_text = {
        let mut response = client
            .get(&format!("{}/api/v1/notifications", mastodon.base))
            .header(Authorization(Bearer::from_str(&mastodon.token).unwrap()))
            .send()
            .unwrap();
        let mut response_text = String::new();
        response.read_to_string(&mut response_text).unwrap();
        response_text
    };
    serde_json::from_str::<Vec<Notification>>(&response_text).unwrap();
}
```
```
running 2 tests
test mastodon::fetch_notification_using_hyper ... FAILED
test mastodon::fetch_notifications ... FAILED

failures:

---- mastodon::fetch_notification_using_hyper stdout ----
        thread 'mastodon::fetch_notification_using_hyper' panicked at 'called `Result::unwrap()` on an `Err` value: ErrorImpl { code: Message("missing field `notification_type`"), line: 1, column: 1810 }', /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libcore/result.rs:868
note: Run with `RUST_BACKTRACE=1` for a backtrace.

---- mastodon::fetch_notifications stdout ----
        thread 'mastodon::fetch_notifications' panicked at 'called `Result::unwrap()` on an `Err` value: Serde(ErrorImpl { code: Message("invalid type: map, expected a string"), line: 1, column: 3 })', /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libcore/result.rs:868


failures:
    mastodon::fetch_notification_using_hyper
    mastodon::fetch_notifications

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured

error: test failed
```
After I added `[serde(rename = "type")]` to `Notification::notification_type`, these 2 tests passed.