### PR TITLE
Fix incompatible serde versions, misspelled reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,5 @@ serde_json = "1"
 serde_derive = "1"
 
 [dependencies.chrono]
-# Locked to 0.3.0 since chrono 0.3.1 uses serde ^1, which is incompatible
-# with serde 0.9 specified above.
-version = "0.3"
+version = "0.4"
 features = ["serde"]

--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -12,7 +12,7 @@ pub struct Account {
     pub header: String,
     pub header_static: String,
     pub locked: bool,
-    pub created_at: DateTime<UTC>,
+    pub created_at: DateTime<Utc>,
     pub followers_count: u64,
     pub following_count: u64,
     pub statuses_count: u64,

--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -7,7 +7,7 @@ pub struct Notification {
     pub id: u64,
     #[serde(rename = "type")]
     pub notification_type: NotificationType,
-    pub created_at: DateTime<UTC>,
+    pub created_at: DateTime<Utc>,
     pub account: Account,
     pub status: Option<Status>,
 }

--- a/src/entities/status.rs
+++ b/src/entities/status.rs
@@ -12,7 +12,7 @@ pub struct Status {
     pub in_reply_to_account_id: Option<u64>,
     pub reblog: Option<Box<Status>>,
     pub content: String,
-    pub created_at: DateTime<UTC>,
+    pub created_at: DateTime<Utc>,
     pub reblogs_count: u64,
     pub favourites_count: u64,
     pub reblogged: Option<bool>,


### PR DESCRIPTION
I copied the sample code from the README, compiled, and got the following error:

```
error[E0277]: the trait bound `chrono::DateTime<chrono::UTC>: serde::Deserialize<'_>` is not satisfied
 --> /home/bt/.cargo/registry/src/github.com-1ecc6299db9ec823/mammut-0.8.0/src/entities/account.rs:2:24
  |
2 | #[derive(Debug, Clone, Deserialize)]
  |                        ^^^^^^^^^^^ the trait `serde::Deserialize<'_>` is not implemented for `chrono::DateTime<chrono::UTC>`
  |
  = note: required by `serde::de::SeqAccess::next_element`

error[E0277]: the trait bound `chrono::DateTime<chrono::UTC>: serde::Deserialize<'_>` is not satisfied
 --> /home/bt/.cargo/registry/src/github.com-1ecc6299db9ec823/mammut-0.8.0/src/entities/account.rs:2:24
  |
2 | #[derive(Debug, Clone, Deserialize)]
  |                        ^^^^^^^^^^^ the trait `serde::Deserialize<'_>` is not implemented for `chrono::DateTime<chrono::UTC>`
  |
  = note: required by `serde::de::MapAccess::next_value`
```

Running `cargo tree -d` showed the following duplicate references to `serde`:

```
serde v0.9.15
└── chrono v0.3.0
    └── mammut v0.8.0 (file:///home/bt/Mammut)

serde v1.0.9
├── mammut v0.8.0 (file:///home/bt/Mammut)
├── reqwest v0.6.2
│   └── mammut v0.8.0 (file:///home/bt/Mammut) (*)
├── serde_json v1.0.2
│   ├── mammut v0.8.0 (file:///home/bt/Mammut) (*)
│   └── reqwest v0.6.2 (*)
└── serde_urlencoded v0.5.1
    └── reqwest v0.6.2 (*)
```

Updating to use `chrono` 0.4 fixed this issue, but introduced a new problem:

```
error[E0277]: the trait bound `chrono::DateTime<chrono::UTC>: serde::Deserialize<'_>` is not satisfied
 --> src/entities/account.rs:2:24
  |
2 | #[derive(Debug, Clone, Deserialize)]
  |                        ^^^^^^^^^^^ the trait `serde::Deserialize<'_>` is not implemented for `chrono::DateTime<chrono::UTC>`
  |
  = note: required by `serde::de::SeqAccess::next_element`

error[E0277]: the trait bound `chrono::DateTime<chrono::UTC>: serde::Deserialize<'_>` is not satisfied
 --> src/entities/account.rs:2:24
  |
2 | #[derive(Debug, Clone, Deserialize)]
  |                        ^^^^^^^^^^^ the trait `serde::Deserialize<'_>` is not implemented for `chrono::DateTime<chrono::UTC>`
  |
  = note: required by `serde::de::MapAccess::next_value`
```

In `chrono` 0.4, [`chrono::UTC` was renamed to `chrono::Utc`](https://github.com/chronotope/chrono/commit/7b9b0c4437548c88f2c849db65cd7064cc7bed3b) to be more idiomatic Rust. Fixing the references resolved the issue.