### PR TITLE
fix(errors): Directly pass up Serde errors for easier debugging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mammut"
-version = "0.8.0"
+version = "0.9.0"
 description = "A wrapper around the Mastodon API."
 authors = ["Aaron Power <theaaronepower@gmail.com>"]
 license = "MIT/Apache-2.0"
@@ -10,7 +10,7 @@ keywords = ["api", "web", "social", "mastodon", "wrapper"]
 categories = ["web-programming", "http-client"]
 
 [dependencies]
-reqwest = "0.6"
+reqwest = "0.8"
 serde = "1"
 serde_json = "1"
 serde_derive = "1"
@@ -18,3 +18,6 @@ serde_derive = "1"
 [dependencies.chrono]
 version = "0.4"
 features = ["serde"]
+
+[dev-dependencies]
+dotenv = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,14 @@ macro_rules! methods {
 
                 match json::from_slice(&vec) {
                     Ok(t) => Ok(t),
-                    Err(e) => Err(e.into()),
+                    // If deserializing into the desired type fails try again to
+                    // see if this is an error response.
+                    Err(e) => {
+                        if let Ok(error) = json::from_slice(&vec) {
+                            return Err(Error::Api(error));
+                        }
+                        Err(e.into())
+                    },
                 }
             }
          )+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,10 +81,9 @@ macro_rules! methods {
                 let mut vec = Vec::new();
                 response.read_to_end(&mut vec)?;
 
-                if let Ok(t) = json::from_slice(&vec) {
-                    Ok(t)
-                } else {
-                    Err(Error::Api(json::from_slice(&vec)?))
+                match json::from_slice(&vec) {
+                    Ok(t) => Ok(t),
+                    Err(e) => Err(e.into()),
                 }
             }
          )+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -623,6 +623,6 @@ mod tests {
             headers: Headers::new()
         };
         let invalid = invalid_test.get::<Account>("test".into()).unwrap_err();
-        assert_eq!(format!("{:?}", invalid), "Serde(ErrorImpl { code: Message(\"missing field `id`\"), line: 1, column: 20 })");
+        assert_eq!(format!("{:?}", invalid), "Serde(ErrorImpl { code: Message(\"missing field `acct`\"), line: 1, column: 20 })");
     }
 }

--- a/tests/upload_photo.rs
+++ b/tests/upload_photo.rs
@@ -15,11 +15,11 @@ fn upload_photo() {
 fn run() -> mammut::Result<()> {
 
     let data = Data {
-        base: String::from(env::var("BASE").unwrap()),
-        client_id: String::from(env::var("CLIENT_ID").unwrap()),
-        client_secret: String::from(env::var("CLIENT_SECRET").unwrap()),
-        redirect: String::from(env::var("REDIRECT").unwrap()),
-        token: String::from(env::var("TOKEN").unwrap()),
+        base: env::var("BASE").unwrap().into(),
+        client_id: env::var("CLIENT_ID").unwrap().into(),
+        client_secret: env::var("CLIENT_SECRET").unwrap().into(),
+        redirect: env::var("REDIRECT").unwrap().into(),
+        token: env::var("TOKEN").unwrap().into(),
     };
 
     let mastodon = Mastodon::from_data(data);


### PR DESCRIPTION
When I was debugging the account ID problem from #15 I got this obscure error:

```
Err(Serde(ErrorImpl { code: Message("missing field `error`"), line: 1, column: 894 }))
```
But there is no error field on the account? How could library think that there is an error field?

With this pull request the error is

```
Err(Serde(ErrorImpl { code: Message("invalid type: string \"28407\", expected u64"), line: 1, column: 13 }))
```
Still quite bad because it does neither mention the type it tries to serialize nor which field is broken, but better than before.