### PR TITLE
tests(upload): Ignore integration test with real Mastodon connection per default

### DIFF
--- a/tests/upload_photo.rs
+++ b/tests/upload_photo.rs
@@ -6,7 +6,10 @@ use std::env;
 use mammut::{Data, Mastodon};
 use dotenv::dotenv;
 
+// Do not run this test by default because it requires a real Mastodon
+// connection setup.
 #[test]
+#[ignore]
 fn upload_photo() {
     dotenv().ok();
     run().unwrap();


### PR DESCRIPTION
This test fails on Travis and can only be run manually anyway.