### PR TITLE
Changes IDs to Strings for compliance with APIv1

### DIFF
--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -24,7 +24,7 @@ pub struct Account {
     /// URL to the header static image (gif).
     pub header_static: String,
     /// The ID of the account.
-    pub id: u64,
+    pub id: String,
     /// Boolean for when the account cannot be followed without waiting for
     /// approval first.
     pub locked: bool,

--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -8,7 +8,7 @@ use super::status::Status;
 #[derive(Debug, Clone, Deserialize)]
 pub struct Notification {
     /// The notification ID.
-    pub id: u64,
+    pub id: String,
     /// The type of notification.
     #[serde(rename = "type")]
     pub notification_type: NotificationType,

--- a/src/entities/report.rs
+++ b/src/entities/report.rs
@@ -4,7 +4,7 @@
 #[derive(Debug, Clone, Deserialize)]
 pub struct Report {
     /// The ID of the report.
-    pub id: u64,
+    pub id: String,
     /// The action taken in response to the report.
     pub action_taken: String,
 }

--- a/src/entities/status.rs
+++ b/src/entities/status.rs
@@ -8,7 +8,7 @@ use status_builder::Visibility;
 #[derive(Debug, Clone, Deserialize)]
 pub struct Status {
     /// The ID of the status.
-    pub id: i64,
+    pub id: String,
     /// A Fediverse-unique resource ID.
     pub uri: String,
     /// URL to the status page (can be remote)
@@ -17,10 +17,10 @@ pub struct Status {
     pub account: Account,
     /// The ID of the status this status is replying to, if the status is
     /// a reply.
-    pub in_reply_to_id: Option<u64>,
+    pub in_reply_to_id: Option<String>,
     /// The ID of the account this status is replying to, if the status is
     /// a reply.
-    pub in_reply_to_account_id: Option<u64>,
+    pub in_reply_to_account_id: Option<String>,
     /// If this status is a reblogged Status of another User.
     pub reblog: Option<Box<Status>>,
     /// Body of the status; this will contain HTML
@@ -63,7 +63,7 @@ pub struct Mention {
     /// Equals `username` for local users, includes `@domain` for remote ones.
     pub acct: String,
     /// Account ID.
-    pub id: u64,
+    pub id: String,
 }
 
 /// Hashtags in the status.


### PR DESCRIPTION
I have seen the other PR where IDs can either be integers or strings, but every API reader implementation I have seen so far is just reading IDs as strings.

Here is Tusky's implementation for example: https://github.com/Vavassor/Tusky/blob/master/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.java#L100

API serialisation for ambiguous values with serde isn't easy and this solution is a lot simpler than separate logic for serialising values of potentially differing types.

I have verified that this works by implementing something similar to #14.