### PR TITLE
style(rustfmt): Run cargo fmt

### DIFF
--- a/examples/print_profile.rs
+++ b/examples/print_profile.rs
@@ -15,7 +15,7 @@ fn main() {
             file.read_to_string(&mut config).unwrap();
             let data: Data = toml::from_str(&config).unwrap();
             Mastodon::from_data(data)
-        },
+        }
         Err(_) => register(),
     };
 

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -20,7 +20,7 @@ pub struct AppBuilder<'a> {
     /// Permission scope of the application.
     pub scopes: Scopes,
     /// URL to the homepage of your application.
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub website: Option<&'a str>,
 }
 
@@ -54,15 +54,19 @@ pub enum Scopes {
 impl fmt::Display for Scopes {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Scopes::*;
-        write!(f, "{}", match *self {
-            All => "read%20write%20follow",
-            Follow => "follow",
-            Read => "read",
-            ReadFollow => "read%20follow",
-            ReadWrite => "read%20write",
-            Write => "write",
-            WriteFollow => "write%20follow"
-        })
+        write!(
+            f,
+            "{}",
+            match *self {
+                All => "read%20write%20follow",
+                Follow => "follow",
+                Read => "read",
+                ReadFollow => "read%20follow",
+                ReadWrite => "read%20write",
+                Write => "write",
+                WriteFollow => "write%20follow",
+            }
+        )
     }
 }
 

--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -2,7 +2,7 @@
 
 use chrono::prelude::*;
 use reqwest::multipart::Form;
-use ::Result;
+use Result;
 use std::path::Path;
 
 /// A struct representing an Account.

--- a/src/entities/attachment.rs
+++ b/src/entities/attachment.rs
@@ -8,7 +8,7 @@ pub struct Attachment {
     /// ID of the attachment.
     pub id: String,
     /// The media type of an attachment.
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub media_type: MediaType,
     /// URL of the locally hosted version of the image.
     pub url: String,
@@ -20,15 +20,13 @@ pub struct Attachment {
     /// (only present on local images)
     pub text_url: Option<String>,
     /// Meta information about the attachment.
-    #[serde(deserialize_with="empty_as_none")]
+    #[serde(deserialize_with = "empty_as_none")]
     pub meta: Option<Meta>,
     /// Noop will be removed.
     pub description: Option<String>,
 }
 
-fn empty_as_none<'de, D: Deserializer<'de>>(val: D)
-    -> Result<Option<Meta>, D::Error>
-{
+fn empty_as_none<'de, D: Deserializer<'de>>(val: D) -> Result<Option<Meta>, D::Error> {
     #[derive(Deserialize)]
     #[serde(untagged)]
     enum EmptyOrMeta {
@@ -62,7 +60,6 @@ pub struct ImageDetails {
     size: String,
     /// The aspect ratio of the attachment.
     aspect: f64,
-
 }
 
 /// The type of media attachment.

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,4 +1,4 @@
-use super::{Mastodon, Result, deserialise};
+use super::{deserialise, Mastodon, Result};
 use reqwest::Response;
 use reqwest::header::{Link, RelationType};
 use serde::Deserialize;
@@ -43,7 +43,7 @@ impl<'a, T: for<'de> Deserialize<'de>> Page<'a, T> {
             initial_items: deserialise(response)?,
             next,
             prev,
-            mastodon
+            mastodon,
         })
     }
 
@@ -52,7 +52,6 @@ impl<'a, T: for<'de> Deserialize<'de>> Page<'a, T> {
         prev: prev_page
     }
 }
-
 
 fn get_links(response: &Response) -> Result<(Option<Url>, Option<Url>)> {
     let mut prev = None;

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -125,13 +125,13 @@ impl Registration {
 
         let token: AccessToken = self.client.post(&url).send()?.json()?;
 
-        Ok(Mastodon::from_registration(self.base,
-                                       self.client_id.unwrap(),
-                                       self.client_secret.unwrap(),
-                                       self.redirect.unwrap(),
-                                       token.access_token,
-                                       self.client))
+        Ok(Mastodon::from_registration(
+            self.base,
+            self.client_id.unwrap(),
+            self.client_secret.unwrap(),
+            self.redirect.unwrap(),
+            token.access_token,
+            self.client,
+        ))
     }
 }
-
-

--- a/src/status_builder.rs
+++ b/src/status_builder.rs
@@ -4,19 +4,19 @@ pub struct StatusBuilder {
     /// The text of the status.
     pub status: String,
     /// Ids of accounts being replied to.
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub in_reply_to_id: Option<u64>,
     /// Ids of media attachments being attached to the status.
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub media_ids: Option<Vec<u64>>,
     /// Whether current status is sensitive.
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sensitive: Option<bool>,
     /// Text to precede the normal status text.
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub spoiler_text: Option<String>,
     /// Visibility of the status, defaults to `Public`.
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub visibility: Option<Visibility>,
 }
 
@@ -38,7 +38,6 @@ pub enum Visibility {
 }
 
 impl StatusBuilder {
-
     /// Create a new status with text.
     /// ```
     /// let status = StatusBuilder::new("Hello World!".into());

--- a/tests/upload_photo.rs
+++ b/tests/upload_photo.rs
@@ -1,5 +1,5 @@
-extern crate mammut;
 extern crate dotenv;
+extern crate mammut;
 
 use std::env;
 
@@ -16,7 +16,6 @@ fn upload_photo() {
 }
 
 fn run() -> mammut::Result<()> {
-
     let data = Data {
         base: env::var("BASE").unwrap().into(),
         client_id: env::var("CLIENT_ID").unwrap().into(),


### PR DESCRIPTION
Every time I modify code to play with this library I have huge diffs because I use `cargo fmt` automatically. Can we cargo fmt here?

Note that I had to revert one change of cargo fmt regarding macros, will file an upstream bug report later.