### PR TITLE
fix(account): Fix moved field on Account

### DIFF
--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -44,7 +44,7 @@ pub struct Account {
     pub source: Option<Source>,
     /// If the owner decided to switch accounts, new account is in
     /// this attribute
-    pub moved: Option<String>,
+    pub moved: Option<Box<Account>>,
 }
 
 /// An extra object given from `verify_credentials` giving defaults about a user


### PR DESCRIPTION
Looks like the Mastodon API has changed, the `moved` property now contains another account object. See https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#accounts