### PR TITLE
Statuses request struct for the `statuses` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mammut"
-version = "0.11.0"
+version = "0.12.0"
 
 description = "A wrapper around the Mastodon API."
 authors = ["Aaron Power <theaaronepower@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mammut"
-version = "0.12.0"
+version = "0.11.0"
 
 description = "A wrapper around the Mastodon API."
 authors = ["Aaron Power <theaaronepower@gmail.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub mod registration;
 pub mod page;
 
 use std::borrow::Cow;
+use std::default::Default;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io::Error as IoError;
@@ -331,6 +332,106 @@ pub struct ApiError {
     pub error: Option<String>,
     /// The description of the error.
     pub error_description: Option<String>,
+}
+
+/// # Example
+///
+/// ```
+/// # extern crate mammut;
+/// # use mammut::StatusesRequest;
+/// let request = StatusesRequest::default()
+///                               .only_media()
+///                               .pinned()
+///                               .since_id("foo");
+/// # assert_eq!(&request.to_querystring()[..], "?only_media=1&pinned=1&since_id=foo");
+/// ```
+#[derive(Clone, Debug)]
+pub struct StatusesRequest {
+    only_media: bool,
+    exclude_replies: bool,
+    pinned: bool,
+    max_id: Option<String>,
+    since_id: Option<String>,
+    limit: Option<usize>,
+}
+
+impl Default for StatusesRequest {
+    fn default() -> StatusesRequest {
+        StatusesRequest {
+            only_media: false,
+            exclude_replies: false,
+            pinned: false,
+            max_id: None,
+            since_id: None,
+            limit: None,
+        }
+    }
+}
+
+impl StatusesRequest {
+    pub fn only_media(mut self) -> Self {
+        self.only_media = true;
+        self
+    }
+
+    pub fn exclude_replies(mut self) -> Self {
+        self.exclude_replies = true;
+        self
+    }
+
+    pub fn pinned(mut self) -> Self {
+        self.pinned = true;
+        self
+    }
+
+    pub fn max_id(mut self, max_id: &str) -> Self {
+        self.max_id = Some(max_id.into());
+        self
+    }
+
+    pub fn since_id(mut self, since_id: &str) -> Self {
+        self.since_id = Some(since_id.into());
+        self
+    }
+
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    pub fn to_querystring(&self) -> String {
+        let mut opts = vec![];
+
+        if self.only_media {
+            opts.push("only_media=1".into());
+        }
+
+        if self.exclude_replies {
+            opts.push("exclude_replies=1".into());
+        }
+
+        if self.pinned {
+            opts.push("pinned=1".into());
+        }
+
+        if let Some(ref max_id) = self.max_id {
+            opts.push(format!("max_id={}", max_id));
+        }
+
+        if let Some(ref since_id) = self.since_id {
+            opts.push(format!("since_id={}", since_id));
+        }
+
+        if let Some(limit) = self.limit {
+            opts.push(format!("limit={}", limit));
+        }
+
+        if opts.is_empty() {
+            String::new()
+        } else {
+            format!("?{}", opts.join("&"))
+        }
+    }
 }
 
 impl Mastodon {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ pub struct ApiError {
 /// ```
 /// # extern crate mammut;
 /// # use mammut::StatusesRequest;
-/// let request = StatusesRequest::default()
+/// let request = StatusesRequest::new()
 ///                               .only_media()
 ///                               .pinned()
 ///                               .since_id("foo");
@@ -355,6 +355,10 @@ pub struct StatusesRequest<'a> {
 }
 
 impl<'a> StatusesRequest<'a> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn only_media(mut self) -> Self {
         self.only_media = true;
         self
@@ -588,12 +592,10 @@ impl Mastodon {
     pub fn statuses<'a, S>(&self, id: &str, request: S) -> Result<Page<Status>>
             where S: Into<Option<StatusesRequest<'a>>>
     {
-        let url = format!("{}/api/v1/accounts/{}/statuses", self.base, id);
-
         let url = if let Some(request) = request.into() {
             request.to_querystring()
         } else {
-            url
+            format!("{}/api/v1/accounts/{}/statuses", self.base, id)
         };
 
         let response = self.client.get(&url)


### PR DESCRIPTION
This changes the signature of `Mastodon::statuses` to take an `id` and a `StatusesRequest` struct. This allows us to pass all the available parameters to `GET /api/v1/accounts/:id/statuses` without adding more and more params to the method signature.

The downside is that it would be a breaking API change, and so would require a version update to 0.12