### PR TITLE
Fix bug in paged_routes_with_id macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,8 +238,10 @@ macro_rules! paged_routes_with_id {
             }
         }
 
-        route!{$($rest)*}
+        paged_routes_with_id!{$($rest)*}
     };
+
+    () => {}
 }
 
 


### PR DESCRIPTION
This bug caused the first method of the `paged_routes_with_id!` block to
be generated correctly, but the last 3 were generated as `route!`s, so
they would fail when called