### PR TITLE
Update reqwest to v0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ categories = ["web-programming", "http-client"]
 
 [dependencies]
 doc-comment = "0.1"
-reqwest = "0.8"
+reqwest = "0.9"
+hyperx = "0.13"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 #[macro_use] extern crate serde_derive;
 #[macro_use] extern crate doc_comment;
 #[macro_use] extern crate serde_json as json;
+extern crate hyperx;
 extern crate chrono;
 extern crate reqwest;
 extern crate serde;
@@ -63,7 +64,7 @@ use std::ops;
 use json::Error as SerdeError;
 use reqwest::Error as HttpError;
 use reqwest::{Client, Response, StatusCode};
-use reqwest::header::{Authorization, Bearer, Headers};
+use reqwest::header::{HeaderMap, HeaderValue};
 use url::ParseError as UrlError;
 
 use entities::prelude::*;
@@ -249,7 +250,7 @@ macro_rules! paged_routes_with_id {
 #[derive(Clone, Debug)]
 pub struct Mastodon {
     client: Client,
-    headers: Headers,
+    headers: HeaderMap,
     /// Raw data about your mastodon instance.
     pub data: Data
 }
@@ -454,8 +455,9 @@ impl Mastodon {
 
             };
 
-            let mut headers = Headers::new();
-            headers.set(Authorization(Bearer { token: (*data.token).to_owned() }));
+            let mut headers = HeaderMap::new();
+            let auth = HeaderValue::from_str(&format!("Bearer {}", data.token));
+            headers.insert(reqwest::header::AUTHORIZATION, auth.unwrap());
 
             Mastodon {
                 client: client,
@@ -466,8 +468,9 @@ impl Mastodon {
 
     /// Creates a mastodon instance from the data struct.
     pub fn from_data(data: Data) -> Self {
-        let mut headers = Headers::new();
-        headers.set(Authorization(Bearer { token: (*data.token).to_owned() }));
+        let mut headers = HeaderMap::new();
+        let auth = HeaderValue::from_str(&format!("Bearer {}", data.token));
+        headers.insert(reqwest::header::AUTHORIZATION, auth.unwrap());
 
         Mastodon {
             client: Client::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ use std::ops;
 use json::Error as SerdeError;
 use reqwest::Error as HttpError;
 use reqwest::{Client, Response, StatusCode};
-use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::header::{self, HeaderMap, HeaderValue};
 use url::ParseError as UrlError;
 
 use entities::prelude::*;
@@ -457,7 +457,7 @@ impl Mastodon {
 
             let mut headers = HeaderMap::new();
             let auth = HeaderValue::from_str(&format!("Bearer {}", data.token));
-            headers.insert(reqwest::header::AUTHORIZATION, auth.unwrap());
+            headers.insert(header::AUTHORIZATION, auth.unwrap());
 
             Mastodon {
                 client: client,
@@ -470,7 +470,7 @@ impl Mastodon {
     pub fn from_data(data: Data) -> Self {
         let mut headers = HeaderMap::new();
         let auth = HeaderValue::from_str(&format!("Bearer {}", data.token));
-        headers.insert(reqwest::header::AUTHORIZATION, auth.unwrap());
+        headers.insert(header::AUTHORIZATION, auth.unwrap());
 
         Mastodon {
             client: Client::new(),

--- a/src/page.rs
+++ b/src/page.rs
@@ -99,8 +99,8 @@ fn get_links(response: &Response) -> Result<(Option<Url>, Option<Url>)> {
 
     let link_header = response.headers().get_all(LINK);
     for value in &link_header {
-        let val = std::convert::From::from(value.to_str().unwrap());
-        let parsed: Link = Header::parse_header(&val).unwrap();
+        let val = std::convert::From::from(value.to_str()?);
+        let parsed: Link = Header::parse_header(&val)?;
         for value in parsed.values() {
             if let Some(relations) = value.rel() {
                 if relations.contains(&RelationType::Next) {

--- a/src/page.rs
+++ b/src/page.rs
@@ -99,20 +99,20 @@ fn get_links(response: &Response) -> Result<(Option<Url>, Option<Url>)> {
 
     let link_header = response.headers().get_all(LINK);
     for value in &link_header {
-        let val = value.to_str().unwrap();
-        let raw = std::convert::From::from(val);
-        let parsed: Link = Header::parse_header(&raw).unwrap();
-        for link_value in parsed.values() {
-            if let Some(relations) = link_value.rel() {
+        let val = std::convert::From::from(value.to_str().unwrap());
+        let parsed: Link = Header::parse_header(&val).unwrap();
+        for value in parsed.values() {
+            if let Some(relations) = value.rel() {
                 if relations.contains(&RelationType::Next) {
-                    next = Some(Url::parse(link_value.link())?);
+                    next = Some(Url::parse(value.link())?);
                 }
 
                 if relations.contains(&RelationType::Prev) {
-                    prev = Some(Url::parse(link_value.link())?);
+                    prev = Some(Url::parse(value.link())?);
                 }
             }
         }
     }
+
     Ok((prev, next))
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,4 +1,4 @@
-use super::{std, Mastodon, Result, deserialise};
+use super::{Mastodon, Result, deserialise};
 use reqwest::Response;
 use reqwest::header::LINK;
 use hyperx::header::{Header, Link, RelationType};
@@ -99,7 +99,7 @@ fn get_links(response: &Response) -> Result<(Option<Url>, Option<Url>)> {
 
     let link_header = response.headers().get_all(LINK);
     for value in &link_header {
-        let val = std::convert::From::from(value.to_str()?);
+        let val = value.to_str()?.into();
         let parsed: Link = Header::parse_header(&val)?;
         for value in parsed.values() {
             if let Some(relations) = value.rel() {


### PR DESCRIPTION
Older version of reqwest can't build by openssl crate error.

```
error: failed to run custom build command for `openssl v0.9.24`
```