### PR TITLE
fix(reqwest): Update reqwest to 0.9 for OpenSSL 1.1.1 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ categories = ["web-programming", "http-client"]
 
 [dependencies]
 doc-comment = "0.1"
-reqwest = "0.8"
+# @todo Remove regex again once reqwest supports typed Link header values again.
+regex = "1"
+reqwest = "0.9"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
@@ -24,3 +26,4 @@ features = ["serde"]
 
 [dev-dependencies]
 toml = "0.4"
+http = "0.1"


### PR DESCRIPTION
Fixes #43 

Do you want to use lazy_static for the regexes or not? Probably not a performance concern in this library since the HTTP requests themselves are orders of magnitude slower.