### PR TITLE
fix(status_builder): Use String as ID type, same as on the entities

### DIFF
--- a/examples/follow_profile.rs
+++ b/examples/follow_profile.rs
@@ -5,7 +5,7 @@ use std::error;
 fn main() -> Result<(), Box<error::Error>> {
     let mastodon = register::get_mastodon_data()?;
     let input = register::read_line("Enter the account id you'd like to follow: ")?;
-    let new_follow = mastodon.follow(input.trim().parse()?)?;
+    let new_follow = mastodon.follow(input.trim())?;
 
     println!("{:#?}", new_follow);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ macro_rules! route_id {
                     "Equivalent to `/api/v1/",
                     $url,
                     "`\n# Errors\nIf `access_token` is not set."),
-                pub fn $name(&self, id: u64) -> Result<$ret> {
+                pub fn $name(&self, id: &str) -> Result<$ret> {
                     self.$method(self.route(&format!(concat!("/api/v1/", $url), id)))
                 }
             }

--- a/src/status_builder.rs
+++ b/src/status_builder.rs
@@ -3,12 +3,13 @@
 pub struct StatusBuilder {
     /// The text of the status.
     pub status: String,
-    /// Ids of accounts being replied to.
+    /// The ID of the status this status is replying to, if the status is
+    /// a reply.
     #[serde(skip_serializing_if="Option::is_none")]
-    pub in_reply_to_id: Option<u64>,
+    pub in_reply_to_id: Option<String>,
     /// Ids of media attachments being attached to the status.
     #[serde(skip_serializing_if="Option::is_none")]
-    pub media_ids: Option<Vec<u64>>,
+    pub media_ids: Option<Vec<String>>,
     /// Whether current status is sensitive.
     #[serde(skip_serializing_if="Option::is_none")]
     pub sensitive: Option<bool>,


### PR DESCRIPTION
In #20 we forgot to convert IDs to the String type for the status builder.