### PR TITLE
feat(media): Add media helper method to create image descriptions

### DIFF
--- a/examples/upload_photo.rs
+++ b/examples/upload_photo.rs
@@ -4,10 +4,9 @@ use std::error;
 
 fn main() -> Result<(), Box<error::Error>> {
     let mastodon = register::get_mastodon_data()?;
-    let file_name = register::read_line("Enter the path to the photo you'd like to post: ")?;
-    let alt_text = register::read_line("Enter the description text for the photo: ")?;
+    let input = register::read_line("Enter the path to the photo you'd like to post: ")?;
 
-    mastodon.media(file_name.into(), Some(alt_text.into()), None)?;
+    mastodon.media(input.into())?;
 
     Ok(())
 }

--- a/examples/upload_photo.rs
+++ b/examples/upload_photo.rs
@@ -4,9 +4,10 @@ use std::error;
 
 fn main() -> Result<(), Box<error::Error>> {
     let mastodon = register::get_mastodon_data()?;
-    let input = register::read_line("Enter the path to the photo you'd like to post: ")?;
+    let file_name = register::read_line("Enter the path to the photo you'd like to post: ")?;
+    let alt_text = register::read_line("Enter the description text for the photo: ")?;
 
-    mastodon.media(input.into())?;
+    mastodon.media(file_name.into(), Some(alt_text.into()), None)?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ pub mod entities;
 pub mod registration;
 /// Handling multiple pages of entities.
 pub mod page;
+/// Constructing media attachments for a status.
+pub mod media_builder;
 
 use std::borrow::Cow;
 use std::error::Error as StdError;
@@ -72,6 +74,7 @@ use hyperx::Error as HyperxError;
 use entities::prelude::*;
 pub use status_builder::StatusBuilder;
 use page::Page;
+pub use media_builder::MediaBuilder;
 
 pub use registration::Registration;
 /// Convience type over `std::result::Result` with `Error` as the error type.
@@ -687,22 +690,19 @@ impl Mastodon {
     }
 
     /// Equivalent to /api/v1/media
-    pub fn media(&self,
-                 file: Cow<'static, str>,
-                 description: Option<Cow<'static, str>>,
-                 focus: Option<(f32, f32)>)
+    pub fn media(&self, media_builder: MediaBuilder)
         -> Result<Attachment>
     {
         use reqwest::multipart::Form;
 
         let mut form_data = Form::new()
-            .file(stringify!(file), file.as_ref())?;
+            .file(stringify!(media_builder.file), media_builder.file.as_ref())?;
 
-        if let Some(description) = description {
+        if let Some(description) = media_builder.description {
             form_data = form_data.text("description", description);
         }
 
-        if let Some(focus) = focus {
+        if let Some(focus) = media_builder.focus {
             let string = format!("{},{}", focus.0, focus.1);
             form_data = form_data.text("focus", string);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -690,8 +690,7 @@ impl Mastodon {
     }
 
     /// Equivalent to /api/v1/media
-    pub fn media(&self, media_builder: MediaBuilder)
-        -> Result<Attachment>
+    pub fn media(&self, media_builder: MediaBuilder) -> Result<Attachment>
     {
         use reqwest::multipart::Form;
 

--- a/src/media_builder.rs
+++ b/src/media_builder.rs
@@ -1,0 +1,45 @@
+use std::borrow::Cow;
+
+/// A builder pattern struct for constructing a media attachment.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct MediaBuilder {
+    /// The file name of the attachment to be uploaded.
+    pub file: Cow<'static, str>,
+    /// The alt text of the attachment.
+    pub description: Option<Cow<'static, str>>,
+    /// The focus point for images.
+    pub focus: Option<(f32, f32)>,
+}
+
+impl MediaBuilder {
+
+    /// Create a new attachment from a file name.
+    pub fn new(file: Cow<'static, str>) -> Self {
+        MediaBuilder {
+            file,
+            description: None,
+            focus: None,
+        }
+    }
+    /// Set an alt text description for the attachment.
+    pub fn description(mut self, description: Cow<'static, str>) -> Self {
+        self.description = Some(description);
+        self
+    }
+
+    /// Set a focus point for an image attachment.
+    pub fn focus(mut self, f1: f32, f2: f32) -> Self {
+        self.focus = Some((f1, f2));
+        self
+    }
+}
+
+impl From<Cow<'static, str>> for MediaBuilder {
+    fn from(file: Cow<'static, str>) -> MediaBuilder {
+        MediaBuilder {
+            file,
+            description: None,
+            focus: None,
+        }
+    }
+}

--- a/src/media_builder.rs
+++ b/src/media_builder.rs
@@ -34,6 +34,32 @@ impl MediaBuilder {
     }
 }
 
+// Convenience helper so that the mastodon.media() method can be called with a
+// file name only (owned string).
+impl From<String> for MediaBuilder {
+    fn from(file: String) -> MediaBuilder {
+        MediaBuilder {
+            file: file.into(),
+            description: None,
+            focus: None,
+        }
+    }
+}
+
+// Convenience helper so that the mastodon.media() method can be called with a
+// file name only (borrowed string).
+impl From<&'static str> for MediaBuilder {
+    fn from(file: &'static str) -> MediaBuilder {
+        MediaBuilder {
+            file: file.into(),
+            description: None,
+            focus: None,
+        }
+    }
+}
+
+// Convenience helper so that the mastodon.media() method can be called with a
+// file name only (Cow string).
 impl From<Cow<'static, str>> for MediaBuilder {
     fn from(file: Cow<'static, str>) -> MediaBuilder {
         MediaBuilder {


### PR DESCRIPTION
Problem: we want to provide alt text descriptions for images because of accessibility.

The Mastodon API supports that via the description parameter, see https://docs.joinmastodon.org/api/rest/media/

I did not want to introduce an API break for the existing media() method, so I created media_description(). What do you think?